### PR TITLE
Add nerves to hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 *Hardware related things like I/O interfaces and such.*
 
 * [elixir_ale](https://github.com/fhunleth/elixir_ale) - Elixir access to hardware I/O interfaces such as GPIO, I2C, and SPI.
+* [nerves](https://github.com/nerves-project/nerves) - Framework for building firmware for platforms like Raspberry Pi and BeagleBone Black.
 
 ## HTTP
 *Libraries for working with HTTP and scraping websites.*


### PR DESCRIPTION
The [nerves project](http://nerves-project.org/) is a young but very interesting framework/toolset for building firmware that targets platforms like Raspberry Pi.
It was featured at ElixirConfEU 2016 ([link to video](https://www.youtube.com/watch?v=118-g0ODfgg))
